### PR TITLE
feat(include): include non-json files as strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,25 @@ module.exports = function( grunt ) {
                 }
             },
 
+            bakeHtml: {
+                files: {
+                    "tmp/simple_html_bake.json": "test/fixtures/simple_html_bake.json",
+                    "tmp/simple_html_multiline_bake.json": "test/fixtures/simple_html_multiline_bake.json",
+                    "tmp/nested_html_bake.json": "test/fixtures/nested_html_bake.json"
+                }
+            },
+
+            bakeHtmlSeparator: {
+                options: {
+                    includeFiles: {
+                        html: { separator: "__"  }
+                    }
+                },
+                files: {
+                    "tmp/simple_html_multiline_separator_bake.json": "test/fixtures/simple_html_multiline_bake.json"
+                }
+            },
+
             comment: {
                 options: {
                     stripComments: true

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ grunt.loadNpmTasks('grunt-json-bake');
 ## The "json_bake" task
 
 ### Overview
-This module allows you to merge multiple JSON files into one. I looks for a certain hooks like so `"key": "{{path/to/folder}}"`.
+This module allows you to merge multiple JSON files into one. It looks for a certain hooks like so `"key": "{{path/to/folder}}"`.
 All values are parsed and replaced. If the hook is a path to a JSON file, the hook will be replaced with the JSON file content.
-If the hook is the path to a folder it will take all the JSON files in this folder and put them into an array.
+If the hook is a path to a another file allowed to be inclued, the hook will be replaced with the file content. If the hook is the path to a folder it will take all the JSON files in this folder and put them into an array.
 
 Includes can be nested. That means any JSON that you include will be recursively parsed a swell. Also folders of JSON files can be nested. When
 a folder is turned into an array it parses the content of a folder for json files. If it comes upon an folder, this will be turned into an array
@@ -68,6 +68,25 @@ Default value: `"/t"`
 This defines the amount of indentation of the JSON being generated. Setting this to `null` will produce a minfied version.
 To get what NPM uses as a default use two spaces: `"  "`.
 
+
+#### options.includeFiles
+Type: `Object` with keys and values. See the default values below.
+
+```javascript
+includeFiles: {
+    json: { resultType: "json"},
+    html: { resultType: "string", separator: ""  },
+    csv: { resultType: "string", separator: ";"  }
+}
+```
+
+The keys of `includeFiles` define the extensions of the files that can be included with `{{filename.ext}}`.
+The `resultType` can have the values `json` or `string`.
+If the `resultType` is `json`, then the file is included as a parsed JSON object.
+If the `resultType` is `string`, then the file content is included as a string.
+If the file content consists of multiple lines you can define the `separator` to connect the lines. 
+
+
 ### Usage Examples
 
 #### Recursive Bake including files and folders
@@ -85,6 +104,7 @@ includes
 ```
 
 This is the `base.json`:
+
 ```json
 {
     "author": "{{includes/author.json}}",

--- a/test/expected/nested_html_bake.json
+++ b/test/expected/nested_html_bake.json
@@ -1,0 +1,7 @@
+{
+	"value": {
+		"keep-going": {
+			"inner": "Fork me at <a href=\"http://github.com\">GitHub</a>.Node me with <a href=\"http://nodejs.org/\">Node.js</a>."
+		}
+	}
+}

--- a/test/expected/simple_html_bake.json
+++ b/test/expected/simple_html_bake.json
@@ -1,0 +1,17 @@
+{
+	"value": "Fork me at <a href=\"http://github.com\">GitHub</a>.",
+	"collection": [
+		{
+			"name": "foo",
+			"value": "bar"
+		},
+		{
+			"name": "1",
+			"value": "2"
+		},
+		{
+			"name": true,
+			"value": false
+		}
+	]
+}

--- a/test/expected/simple_html_multiline_bake.json
+++ b/test/expected/simple_html_multiline_bake.json
@@ -1,0 +1,17 @@
+{
+	"value": "Fork me at <a href=\"http://github.com\">GitHub</a>.Node me with <a href=\"http://nodejs.org/\">Node.js</a>.",
+	"collection": [
+		{
+			"name": "foo",
+			"value": "bar"
+		},
+		{
+			"name": "1",
+			"value": "2"
+		},
+		{
+			"name": true,
+			"value": false
+		}
+	]
+}

--- a/test/expected/simple_html_multiline_separator_bake.json
+++ b/test/expected/simple_html_multiline_separator_bake.json
@@ -1,0 +1,17 @@
+{
+	"value": "Fork me at <a href=\"http://github.com\">GitHub</a>.__Node me with <a href=\"http://nodejs.org/\">Node.js</a>.",
+	"collection": [
+		{
+			"name": "foo",
+			"value": "bar"
+		},
+		{
+			"name": "1",
+			"value": "2"
+		},
+		{
+			"name": true,
+			"value": false
+		}
+	]
+}

--- a/test/fixtures/multiline.html
+++ b/test/fixtures/multiline.html
@@ -1,0 +1,2 @@
+Fork me at <a href="http://github.com">GitHub</a>.
+Node me with <a href="http://nodejs.org/">Node.js</a>.

--- a/test/fixtures/nested-a/file_html.json
+++ b/test/fixtures/nested-a/file_html.json
@@ -1,0 +1,3 @@
+{
+    "keep-going": "{{nested-b/file_html.json}}"
+}

--- a/test/fixtures/nested-a/nested-b/file_html.json
+++ b/test/fixtures/nested-a/nested-b/file_html.json
@@ -1,0 +1,3 @@
+{
+    "inner": "{{multiline.html}}"
+}

--- a/test/fixtures/nested-a/nested-b/multiline.html
+++ b/test/fixtures/nested-a/nested-b/multiline.html
@@ -1,0 +1,2 @@
+Fork me at <a href="http://github.com">GitHub</a>.
+Node me with <a href="http://nodejs.org/">Node.js</a>.

--- a/test/fixtures/nested_html_bake.json
+++ b/test/fixtures/nested_html_bake.json
@@ -1,0 +1,3 @@
+{
+    "value": "{{nested-a/file_html.json}}"
+}

--- a/test/fixtures/one-line.html
+++ b/test/fixtures/one-line.html
@@ -1,0 +1,1 @@
+Fork me at <a href="http://github.com">GitHub</a>.

--- a/test/fixtures/simple_html_bake.json
+++ b/test/fixtures/simple_html_bake.json
@@ -1,0 +1,4 @@
+{
+    "value": "{{one-line.html}}",
+    "collection": "{{folder}}"
+}

--- a/test/fixtures/simple_html_multiline_bake.json
+++ b/test/fixtures/simple_html_multiline_bake.json
@@ -1,0 +1,4 @@
+{
+    "value": "{{multiline.html}}",
+    "collection": "{{folder}}"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,11 @@ exports.bake = {
             "tmp/nested_folder_bake.json": "test/expected/nested_folder_bake.json",
             "tmp/comment_bake.json": "test/expected/comment_bake.json",
             "tmp/minified.json": "test/expected/minified.json",
-            "tmp/small_indentation.json": "test/expected/small_indentation.json"
+            "tmp/small_indentation.json": "test/expected/small_indentation.json",
+            "tmp/simple_html_bake.json": "test/expected/simple_html_bake.json",
+            "tmp/simple_html_multiline_bake.json": "test/expected/simple_html_multiline_bake.json",
+            "tmp/simple_html_multiline_separator_bake.json": "test/expected/simple_html_multiline_separator_bake.json",
+            "tmp/nested_html_bake.json": "test/expected/nested_html_bake.json"
         };
 
         test.expect( mout.object.size( files ) );


### PR DESCRIPTION
Add the following default options:

``` javascript
includeFiles: {
    json: { resultType: "json"},
    html: { resultType: "string", separator: ""  },
    csv: { resultType: "string", separator: ";"  }
}
```

Add tests for the new options.

Only files defined in includeFiles will be included. There are no checks for binary files. The result type `array` is not yet supported.

Is that acceptable? Tell me if I can help further.
